### PR TITLE
noRollbackFor가 동작하기 위한 테스트 코드 수정

### DIFF
--- a/Ch11/transactions5-springdata/src/test/java/com/manning/javapersistence/ch11/concurrency/TransactionPropagationTest.java
+++ b/Ch11/transactions5-springdata/src/test/java/com/manning/javapersistence/ch11/concurrency/TransactionPropagationTest.java
@@ -128,7 +128,7 @@ public class TransactionPropagationTest {
         itemRepository.addItemNoRollback("Item2", LocalDate.of(2022, 3, 1));
         itemRepository.addItemNoRollback("Item3", LocalDate.of(2022, 1, 1));
 
-        DuplicateItemNameException ex = assertThrows(DuplicateItemNameException.class, () -> itemRepository.addItem("Item2", LocalDate.of(2016, 3, 1)));
+        DuplicateItemNameException ex = assertThrows(DuplicateItemNameException.class, () -> itemRepository.addItemNoRollback("Item2", LocalDate.of(2016, 3, 1)));
         assertAll(
                 () -> assertEquals("Item with name Item2 already exists", ex.getMessage()),
                 () -> assertEquals(4, logRepository.findAll().size()),


### PR DESCRIPTION
안녕하세요.

`noRollback()` 테스트 코드에 수정이 필요해 보이는 부분이 있어서 PR요청 올렸습니다.

`noRollback()` 테스트 코드의 다음 부분을 보면...

* https://github.com/wikibook/javapersistence/blob/2309dd78636b354c53713d746275c2c046bf01b4/Ch11/transactions5-springdata/src/test/java/com/manning/javapersistence/ch11/concurrency/TransactionPropagationTest.java#L131

`ItemRepositoryImpl#addItemNoRollback()` 메서드 위에 선언한,
`@Transactional(noRollbackFor = DuplicateItemNameException.class)`의 동작을 확인하기 위한 코드인데,
중복을 예외를 발생시키려할 때는 `ItemRepositoryImpl#addItem()`으로 잘못 사용하고 있습니다.

`ItemRepositoryImpl#addItem()`은 `LogRepository#log()`와 함깨 `REQUIRES_NEW` 동작을 확인하기 위한 메서드입니다.

`noRollbackFor`을 동작시키기 위해서는 중복된 정보 입력시 `addItemNoRollback()`를 사용해야합니다.

감사합니다. 좋은하루되세요. 👍